### PR TITLE
Print a message for images that cannot be colored instead of the whole chapter failing

### DIFF
--- a/Backend/inference.py
+++ b/Backend/inference.py
@@ -42,7 +42,10 @@ def colorize_images(target_path, colorizator, args):
 
         print('[+] C:', file_path)
         save_path = os.path.join(target_path, image_name)
-        colorize_single_image(file_path, save_path, colorizator, args)
+        try:
+            colorize_single_image(file_path, save_path, colorizator, args)
+        except Exception as ex:
+            print("Could not colorize: ", file_path, ex)
     
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
try/except around call to colorize_single_image in colorize_images in inference.py

Error messages like "image file is truncated (42 bytes not processed)" were causing the whole batch image process to fail. After this change, the batch process completes and is able to serve the successfully colorized images. A 404 error occurs when a colored image is requested that could not be generated, but all good images are shown.